### PR TITLE
Add `transitionBackOnClick` props

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,14 @@ Function called when clicking on an option on the left. Received the clicked opt
 
 Also called swiping far to the right (if applicable).
 
+##### transitionBackOnRightClick
+
+Boolean defining if it should transition back to the default state after a right-side item is clicked/tapped. Defaults to true.
+
+##### transitionBackOnLeftClick
+
+Boolean defining if it should transition back to the default state after a left-side item is clicked/tapped. Defaults to true.
+
 ##### onReveal
 
 Function called when showing options once the swipe is over. Receive `'left'` or `'right'`as an argument.

--- a/react-swipe-to-reveal-options.js
+++ b/react-swipe-to-reveal-options.js
@@ -192,6 +192,8 @@
       transitionBackTimeout: React.PropTypes.number,
       callActionWhenSwipingFarLeft: React.PropTypes.bool,
       callActionWhenSwipingFarRight: React.PropTypes.bool,
+      transitionBackOnRightClick: React.PropTypes.bool,
+      transitionBackOnLeftClick: React.PropTypes.bool,
       closeOthers: React.PropTypes.func,
       onRightClick: React.PropTypes.func,
       onLeftClick: React.PropTypes.func,
@@ -210,7 +212,9 @@
         transitionBack: false,
         action: null,
         callActionWhenSwipingFarRight: false,
-        callActionWhenSwipingFarLeft: false
+        callActionWhenSwipingFarLeft: false,
+        transitionBackOnRightClick: true,
+        transitionBackOnLeftClick: true
       };
     },
 
@@ -399,12 +403,12 @@
 
     rightClick: function rightClick(option) {
       this.props.onRightClick(option);
-      this.transitionBack();
+      if (this.props.transitionBackOnRightClick) this.transitionBack();
     },
 
     leftClick: function leftClick(option) {
       this.props.onLeftClick(option);
-      this.transitionBack();
+      if (this.props.transitionBackOnLeftClick) this.transitionBack();
     },
 
     close: function close() {


### PR DESCRIPTION
Relates to #19 

I know I said I'd wait and see what you thought, but it turned out to be a really easy thing to implement, and I do need it for my project.

This PR allows you to disable `transitionBack` from firing on left and/or right button tap. When using animations, it turns this:

![](http://i.imgur.com/LwuaJu8.gif)

Into this:

![](http://i.imgur.com/sT4xyWI.gif)

No hard feelings if you don't feel like this edge case is worth merging in :) Happy to tweak it to fit the project's needs, but just as happy to keep using my fork.
